### PR TITLE
Add ability to continue parsing even if an empty xml file

### DIFF
--- a/Format.py
+++ b/Format.py
@@ -260,7 +260,12 @@ class VOC:
 
                 objects = root.findall("object")
                 if len(objects) == 0:
-                    return False, "number object zero"
+                    # no objects in xml file
+                    choice = input("\nNo objects in current xml file, continue parsing other files? [yes/no] ")
+                    if choice.lower() in ["y", "yes"]:
+                        continue
+                    else:
+                        return False, "number object zero"
 
                 obj = {
                     "num_obj": len(objects)


### PR DESCRIPTION
If an "empty" (damaged) xml file is encountered during the parsing process, the user will have the choice to continue converting other files.
In some datasets, there are such "empty" files, for example, in LaDD dataset (https://github.com/lacmus-foundation/lacmus)